### PR TITLE
Mfw 771 Fix Intermittent uqmi hangs

### DIFF
--- a/caswell-rssi-leds/files/caswell-rssi-leds
+++ b/caswell-rssi-leds/files/caswell-rssi-leds
@@ -1,30 +1,34 @@
 #!/bin/sh
 
+. /lib/functions/network.sh
 . /usr/share/libubox/jshn.sh
 
 # init
 i2cset -y 0 0x21 0x01 0x00
 i2cset -y 0 0x21 0x03 0x00
 
-while [ 1 ] ; do
-
-	status="$(uqmi -s -d /dev/cdc-wdm0 --get-data-status)"
-	if [ $status = "\"disconnected\"" ] ; then
-		i2cset -y 0 0x21 0x01 0x00
-	else
-		rssi=-100
-		json_load "$(uqmi -s -d /dev/cdc-wdm0 --get-signal-info)"
-		json_get_var rssi rssi
-
-		if [ $rssi -ge -65 ] ; then
-			i2cset -y 0 0x21 0x01 0xf0
-		elif [ $rssi -le -64 -a $rssi -ge -75 ] ; then
-			i2cset -y 0 0x21 0x01 0x70
-		elif [ $rssi -le -74 -a $rssi -ge -85 ] ; then
-			i2cset -y 0 0x21 0x01 0x30
+if network_is_up LTE ; then
+	while [ 1 ] ; do
+		status="$(uqmi -s -d /dev/cdc-wdm0 --get-data-status)"
+		if [ $status = "\"disconnected\"" ] ; then
+			i2cset -y 0 0x21 0x01 0x00
 		else
-			i2cset -y 0 0x21 0x01 0x10
+			rssi=-100
+			json_load "$(uqmi -s -d /dev/cdc-wdm0 --get-signal-info)"
+			json_get_var rssi rssi
+
+			if [ $rssi -ge -65 ] ; then
+				i2cset -y 0 0x21 0x01 0xf0
+			elif [ $rssi -le -64 -a $rssi -ge -75 ] ; then
+				i2cset -y 0 0x21 0x01 0x70
+			elif [ $rssi -le -74 -a $rssi -ge -85 ] ; then
+				i2cset -y 0 0x21 0x01 0x30
+			else
+				i2cset -y 0 0x21 0x01 0x10
+			fi
 		fi
-	fi
-	sleep 10
-done
+		sleep 10
+	done
+else
+	i2cset -y 0 0x21 0x01 0x00
+fi

--- a/caswell-rssi-leds/files/caswell-rssi-leds.init
+++ b/caswell-rssi-leds/files/caswell-rssi-leds.init
@@ -6,10 +6,31 @@ STOP=19
 
 USE_PROCD=1
 
+device="/dev/cdc-wdm0"
+
+get_sim_info()
+{
+
+	imei=$(uqmi -s -d $device --get-imei | cut -d "\"" -f 2)
+	msisdn=$(uqmi -s -d $device --get-msisdn  | cut -d "\"" -f 2)
+	iccid=$(uqmi -s -d $device --get-iccid | cut -d "\"" -f 2)
+	imsi=$(uqmi -s -d $device --get-imsi | cut -d "\"" -f 2)
+
+	json_init
+	json_add_string iccid $iccid
+	json_add_string imsi $imsi
+	json_add_string imei $imei
+	json_add_string msisdn $msisdn
+	json_close_object
+
+	echo "$(json_dump)" > /tmp/wwan_sim_info.wwan0
+}
+
 boot() {
     grep -q -e caswell-caf-0262 -e untangle-inc-default-string /tmp/sysinfo/board_name
-    if [ $? -eq 0 ] ; then
+    if [ $? -eq 0 -a -c "$device" ] ; then
 	CASWELL_BOOT=1
+	get_sim_info
 	start "$@"
     fi
 }

--- a/caswell-rssi-leds/files/caswell-rssi-leds.init
+++ b/caswell-rssi-leds/files/caswell-rssi-leds.init
@@ -48,6 +48,6 @@ start_service() {
 }
 
 service_triggers() {
-    procd_add_interface_trigger "interface.*.up" "LTE" /etc/init.d/caswell-rssi-leds start
+    procd_add_interface_trigger "interface.*.up" "LTE" /etc/init.d/caswell-rssi-leds restart
 }
 

--- a/sync-settings/files/wwan_status.sh
+++ b/sync-settings/files/wwan_status.sh
@@ -3,48 +3,11 @@
 . /usr/share/libubox/jshn.sh
 
 interface=$1
-full_path="/sys/class/net/$interface"
+sim_info_path="/tmp/wwan_sim_info.$interface"
 
-if [ ! -z "${interface##wwan*}" ] ; then
+if [ -f $sim_info_path  ] ; then
+	cat $sim_info_path
+else
 	echo {}
-	return
 fi
-
-if [ ! -L $full_path ] ; then
-	echo {}
-	return
-fi
-
-device="/dev/$(ls /sys/class/net/$interface/device/usbmisc)"
-
-imei=$(uqmi -s -d $device --get-imei | cut -d "\"" -f 2)
-msisdn=$(uqmi -s -d $device --get-msisdn  | cut -d "\"" -f 2)
-data_status=$(uqmi -s -d $device --get-data-status | cut -d "\"" -f 2)
-iccid=$(uqmi -s -d $device --get-iccid | cut -d "\"" -f 2)
-imsi=$(uqmi -s -d $device --get-imsi | cut -d "\"" -f 2)
-
-json_load "$(uqmi -s -d $device --get-serving-system)"
-json_get_vars registration plmn_mcc plmn_mnc plmn_description roaming
-
-json_load "$(uqmi -s -d $device --get-signal-info)"
-json_get_vars type rssi rsrq rsrp snr
-
-json_init
-json_add_string registration $registration
-json_add_int plmn_mcc $plmn_mcc
-json_add_int plmn_mnc $plmn_mnc
-json_add_string plmn_description $plmn_description
-json_add_boolean roaming $roaming
-json_add_string type $type
-json_add_int rssi $rssi
-json_add_int rsrq $rsrq
-json_add_int rsrp $rsrp
-json_add_int snr $snr
-json_add_string data_status $data_status
-json_add_string iccid $iccid
-json_add_string imsi $imsi
-json_add_string imei $imei
-json_add_string msisdn $msisdn
-json_close_object
-echo "$(json_dump)"
 


### PR DESCRIPTION
The uqmi utility is used to communicate with the LTE modem on the Untangle e6wl.  It is used for three things:

1.  Configuring the interface to create the actual network connection
2.  A script periodically polls the signal strength to update the rssi leds on the box
3.  The UI (via a status api) calls it to get sim details to display

It turns out that multiple instances of uqmi running at the same time can cause one or more of the instances to hang indefinitely.

The right fix here is probably to change uqmi (and possibly the driver) to allow multiple instances at the same time.  But that seemed out of scope for 1.1.

Another possible fix was to use something like flock to serialize all calls to uqmi.  This would work, but would involve changing the upstream qmi netifd protocol handler, which I'd like to avoid doing.

The changes in this pull request tweak our current scripts such that that uqmi calls to accomplish the three tasks above are never called at the same time. 