### PR TITLE
MFW-802: caswell-rssi-leds: Reset modem at boot

### DIFF
--- a/caswell-rssi-leds/files/caswell-rssi-leds.init
+++ b/caswell-rssi-leds/files/caswell-rssi-leds.init
@@ -8,6 +8,12 @@ USE_PROCD=1
 
 device="/dev/cdc-wdm0"
 
+reset_modem()
+{
+	uqmi -s -d $device --set-device-operating-mode offline
+	uqmi -s -d $device --set-device-operating-mode reset
+}
+
 get_sim_info()
 {
 
@@ -31,6 +37,7 @@ boot() {
     if [ $? -eq 0 -a -c "$device" ] ; then
 	CASWELL_BOOT=1
 	get_sim_info
+	reset_modem
 	start "$@"
     fi
 }


### PR DESCRIPTION
This will ensure we are starting from a fresh configuration.  In the
cases of a loss of power or a sysupgrade we may not have properly
shut down the LTE connection prior to rebooting.  That can leave
the modem in a state in which it thinks its connected, but isn't.
In this state, no amount of configuring the device will ever get
it back on line.  Only a modem reset will do.

MFW-802