### PR TITLE
MFW-794: license-scripts: Create fake unlimited license for linksys and virtua…

### DIFF
--- a/license-scripts/files/fetch-licenses.sh
+++ b/license-scripts/files/fetch-licenses.sh
@@ -29,20 +29,34 @@ OUTPUT="/tmp/licenses.json"
 SIMULATE=0
 FILE="/etc/config/licenses.json"
 
-echo "Downloading licenses from $URL... "
-rm -f $OUTPUT
+if test "${BOARD#*linksys*}" != "$BOARD" || test "${BOARD#*virtualbox*}" != "$BOARD" ; then
+    cat > $FILE <<'EOF'
+{
+    "javaClass": "java.util.LinkedList",
+    "list": [
+        {
+            "seats": 1000000
+        }
+    ]
+}
+EOF
 
-wget -t 5 --timeout=30 -q -O $OUTPUT $URL
-if [ $? != 0 ] ; then
-    echo "Failed to download licenses ($?)."
-    exit 1
 else
-    echo "Saving licenses in $FILE"
-    cp $OUTPUT $FILE
+    echo "Downloading licenses from $URL... "
+    rm -f $OUTPUT
 
-    # rerun our qos scripts to sync license limit
-    /etc/init.d/qos restart
+    wget -t 5 --timeout=30 -q -O $OUTPUT $URL
+    if [ $? != 0 ] ; then
+        echo "Failed to download licenses ($?)."
+        exit 1
+    else
+        echo "Saving licenses in $FILE"
+        cp $OUTPUT $FILE
+    fi
 fi
+
+# rerun our qos scripts to sync license limit
+/etc/init.d/qos restart
 
 
 


### PR DESCRIPTION
…lbox devices

Just populate the seats with 1000000, which means "unlimited".
Filling out just this field allows these devices to set qos,
shows "Unlimited" on the dashboard, but doesn't show any details
under Settings->System->License.

MFW-794