### PR TITLE
MFW-910: sync-settings: Run 'sync-settings -n' at boot

### DIFF
--- a/sync-settings/files/sync-settings.init
+++ b/sync-settings/files/sync-settings.init
@@ -11,6 +11,8 @@ boot() {
     if [ ! -f /etc/config/settings.json ] ; then
         logger -t "sync-settings" "Creating /etc/config/settings.json"
         /usr/bin/sync-settings -c -n | logger -t "sync-settings"
+    else
+        /usr/bin/sync-settings -n | logger -t "sync-settings"
     fi
 
     if [ ! -f /etc/config/defaults.json ] ; then


### PR DESCRIPTION
This will ensure the configuration files written out to the system
are in sync with the current firmware image.

MFW-910