### PR TITLE
license-scripts: Add startup script

### DIFF
--- a/license-scripts/Makefile
+++ b/license-scripts/Makefile
@@ -31,6 +31,9 @@ define Package/license-scripts/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) files/fetch-licenses.sh $(1)/usr/bin/
 	$(INSTALL_BIN) files/interface-kbps $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) files/fetch-licenses.init $(1)/etc/init.d/fetch-licenses
 endef
 
 $(eval $(call BuildPackage,license-scripts))

--- a/license-scripts/files/fetch-licenses.init
+++ b/license-scripts/files/fetch-licenses.init
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+# this can happen late
+START=99
+STOP=99
+
+boot() {
+    # if we dont' have a license file on boot
+    # try fetching one
+    if [ ! -f /etc/config/licenses.json ] ; then
+        /usr/bin/fetch-licenses.sh
+    fi
+}


### PR DESCRIPTION
Try to fetch licenses at startup if there isn't a license file.
That way a box will have the correct bandwidth limits and qos
restrictions right off the bat if a valid license for the box
already exists when the box is initially being set up.  It also
ensures that unlimited boxes like linksys and virtualbox have their
unlimited license file populated immediately

MFW-978