### PR TITLE
fetch-licenses: Add "untangle-node-throughput" to fake license

### DIFF
--- a/license-scripts/files/fetch-licenses.sh
+++ b/license-scripts/files/fetch-licenses.sh
@@ -35,6 +35,7 @@ if test "${BOARD#*linksys*}" != "$BOARD" || test "${BOARD#*virtualbox*}" != "$BO
     "javaClass": "java.util.LinkedList",
     "list": [
         {
+            "name": "untangle-node-throughput",
             "seats": 1000000
         }
     ]


### PR DESCRIPTION
While merely defining the seats is sufficient to trick the UI
into thinking virtualbox/linksys has an unlimited license, the
interface-kpbs script actually checks if the name of the license
is "untangle-node-throughput".

MFW-1000