### PR TITLE
sync-settings: Remove defaults.json

### DIFF
--- a/sync-settings/files/sync-settings.init
+++ b/sync-settings/files/sync-settings.init
@@ -15,11 +15,7 @@ boot() {
         /usr/bin/sync-settings -n | logger -t "sync-settings"
     fi
 
-    if [ ! -f /etc/config/defaults.json ] ; then
-        /usr/bin/sync-settings -c -s -f /etc/config/defaults.json
-    fi
-
-    # FIXME
-    # We need to check the version and call an upgrade utility if the version of the settings is out-of-date
-    # If we upgrade the settings we should recreate defaults.json
+    # remove /etc/config/defaults.json
+    # we used to create it here, but never used it for anything
+    rm -f /etc/config/defaults.json
 }


### PR DESCRIPTION
We initially added the generation of defaults.json as a possible
vehicle for resetting all or partial settings back to defaults.
However, we never actually used this functionality.  Don't generate
defaults.json anymore and delete it if its already there.

MFW-1106