### PR TITLE
sync-settings: Refresh defaults.json on every boot

### DIFF
--- a/sync-settings/files/sync-settings.init
+++ b/sync-settings/files/sync-settings.init
@@ -15,11 +15,7 @@ boot() {
         /usr/bin/sync-settings -n | logger -t "sync-settings"
     fi
 
-    if [ ! -f /etc/config/defaults.json ] ; then
-        /usr/bin/sync-settings -c -s -f /etc/config/defaults.json
-    fi
-
-    # FIXME
-    # We need to check the version and call an upgrade utility if the version of the settings is out-of-date
-    # If we upgrade the settings we should recreate defaults.json
+    # ensure we have an up to date defaults.json file
+    /usr/bin/sync-settings -c -s -f /tmp/settings.json
+    mv /tmp/settings.json /etc/config/defaults.json
 }


### PR DESCRIPTION
To ensure that defaults.json is up to date with the currently running
code, re-generate it on every boot

MFW-1106