### PR TITLE
Enable zram-swap on linksys devices

### DIFF
--- a/configs/device/wrt1900/target
+++ b/configs/device/wrt1900/target
@@ -1,3 +1,4 @@
 CONFIG_TARGET_mvebu=y
 CONFIG_TARGET_mvebu_cortexa9=y
 CONFIG_TARGET_mvebu_cortexa9_DEVICE_linksys_wrt1900acs=y
+CONFIG_PACKAGE_zram-swap=y

--- a/configs/device/wrt3200/target
+++ b/configs/device/wrt3200/target
@@ -1,3 +1,4 @@
 CONFIG_TARGET_mvebu=y
 CONFIG_TARGET_mvebu_cortexa9=y
 CONFIG_TARGET_mvebu_cortexa9_DEVICE_linksys_wrt3200acm=y
+CONFIG_PACKAGE_zram-swap=y

--- a/configs/device/wrt32x/target
+++ b/configs/device/wrt32x/target
@@ -1,3 +1,4 @@
 CONFIG_TARGET_mvebu=y
 CONFIG_TARGET_mvebu_cortexa9=y
 CONFIG_TARGET_mvebu_cortexa9_DEVICE_linksys_wrt32x=y
+CONFIG_PACKAGE_zram-swap=y


### PR DESCRIPTION
We have enabled zram-swap on the linksys devices to solve the "cannot allocate memory" error we see when some golang and
python apps attempt to spawn external processes to get status or modify system configuration. We think this will improve kernel memory management so it can better handle exec requests made by applications that have a large memory footprint. This change was applied for wrt1900, wrt3200, and wrt32x devices.