### PR TITLE
turn off ip reputation cache in bctid

### DIFF
--- a/bctid/files/bcti.cfg.sdwan
+++ b/bctid/files/bcti.cfg.sdwan
@@ -84,7 +84,7 @@ EnableIpRtu=False
 # IpGeoCacheSize: The maximum number of cached geo entries.
 IpGeoCacheSize=2000
 # IpRepCacheSize: The maximum number of cached reputation entries.
-IpRepCacheSize=2000
+IpRepCacheSize=0
 # IpFileMask is a bitmask, set the appropriate bits to download a specific
 # set of databases or specify 4096 for everything. For 1-8, specify 255 and so on
 # 0 = Spam Sources


### PR DESCRIPTION
In order to work around a know issue with the bctid daemon where cached lookup is not working, we will disable the cache by setting it's size to 0.
