### PR TITLE
Fix insufficient memory issue and improve error detection and handling

### DIFF
--- a/sync-settings/files/speedtest.sh
+++ b/sync-settings/files/speedtest.sh
@@ -1,15 +1,26 @@
 #!/bin/sh
 
-# ./speedtest.sh interface
+# MFW-1606 Added --no-pre-allocate argument when calling speedtest-cli as it
+# often fails to allocate memory during the upload test, especially on
+# limited hardware. Improved error detection and handling.
+# Our version of speedtest-cli on success returns a result in this format:
+# {"ping":12,"download":,12345,"upload":1234}
+# On failure we can't simply return {} because the user interface will
+# throw an error since the expected key/value pairs are missing.
+# So now we return {"error":"message"} if something goes wrong so the
+# UI can detect and display the error message, otherwise we'll return
+# the JSON result we get from the utility.
+
+# USAGE: ./speedtest.sh interface
 
 get_ipv4_address() {
 	intf=$1
-	ifconfig $intf | awk '/inet addr/{print substr($2,6)}' | head -n1
+	ifconfig $intf 2>/dev/null | awk '/inet addr/{print substr($2,6)}' | head -n1
 }
 
 get_ipv6_address() {
 	intf=$1
-	ifconfig $intf | grep Global | awk '/inet6 addr/{print substr($3,1)}' | cut -d '/' -f 1 | head -n1
+	ifconfig $intf 2>/dev/null | grep Global | awk '/inet6 addr/{print substr($3,1)}' | cut -d '/' -f 1 | head -n1
 }
 
 get_ip_address() {
@@ -19,7 +30,6 @@ get_ip_address() {
 	if [ -z $ip_address ] ; then
 		ip_address=$(get_ipv6_address $intf)
 	fi
-
 
 	echo $ip_address
 }
@@ -42,20 +52,22 @@ enable_qos() {
 
 interface=$1
 if [ -z $interface ] ; then
-	echo "No interface specified"
+    echo "{\"error\":\"No interface specified\"}"
 	exit 1
 fi
 
 ip_address=$(get_ip_address $interface)
 if [ -z $ip_address ] ; then
-	echo "$interface has no ip address"
+    echo "{\"error\":\"Interface has no IP address\"}"
 	exit 1
 fi
 
 disable_qos $interface
-RESULT=$(/usr/bin/speedtest-cli --simple-json --source $ip_address 2>/dev/null)
+OUTPUT=$(/usr/bin/speedtest-cli --simple-json --no-pre-allocate --source $ip_address 2>&1)
 if [ $? -ne 0 ] ; then
-	RESULT="{}"
+	RESULT="{\"error\":\"$OUTPUT\"}"
+else
+    RESULT=$OUTPUT
 fi
 enable_qos $interface
 echo $RESULT


### PR DESCRIPTION
Fixed the speedtest.sh script so it always outputs a valid json object, either an error message that can be detected by the UI code, or the json result generated by the speedtest-cli utility. Added the --no-pre-allocate when calling speedtest-cli to prevent out of memory errors during the upload test on devices with limited memory.