### PR TITLE
sync-settings.init: during upgrade and reboot, if previous invalid se…

### DIFF
--- a/sync-settings/files/sync-settings.init
+++ b/sync-settings/files/sync-settings.init
@@ -10,9 +10,9 @@ boot() {
 
     if [ ! -f /etc/config/settings.json ] ; then
         logger -t "sync-settings" "Creating /etc/config/settings.json"
-        /usr/bin/sync-settings -c -n | logger -t "sync-settings"
+        /usr/bin/sync-settings -c -n -v force=true | logger -t "sync-settings"
     else
-        /usr/bin/sync-settings -n | logger -t "sync-settings"
+        /usr/bin/sync-settings -n -v force=true | logger -t "sync-settings"
     fi
 
     # ensure we have an up to date defaults.json file


### PR DESCRIPTION
…ttings existed, we should force disabling of that policy or rule