### PR TITLE
Mfw 1962

### DIFF
--- a/sync-settings/files/setup.init
+++ b/sync-settings/files/setup.init
@@ -1,8 +1,8 @@
 #!/bin/sh /etc/rc.common
 
 # 15 is right after sync-settings (14)
-START=15
-STOP=15
+START=16
+STOP=16
 
 boot() {
     if [ -d /etc/config/setup.d/ ] ; then

--- a/sync-settings/files/setup.init
+++ b/sync-settings/files/setup.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-# 15 is right after sync-settings (14)
+# 16 is right after startup (15)
 START=16
 STOP=16
 


### PR DESCRIPTION
We need to run setup after startup. Main issue is that with https://github.com/untangle/mfw_feeds/pull/74 we moved some things from startup to setup (timezone and set-passwd) however we did not handle the upgrade scenario. 
The easiest fix is to make sure that setup always runs after the scripts in startup, so even if there are left over scripts in startup those will be overwritten by the same scripts in setup.