### PR TITLE
MFW 2200: Correct shell substitution.

### DIFF
--- a/pyconnector/files/pyconnector.init
+++ b/pyconnector/files/pyconnector.init
@@ -21,7 +21,7 @@ get_translated_host()
         host=$translated_url
     fi
     # Strip leading https://
-    host=${server##https://}
+    host=${host##https://}
     # Strip trailing path
     host=${host%%/*}
 


### PR DESCRIPTION
Correct a shell substitution that caused the host variable to be empty, see https://jira.untangle.com/browse/MFW-2200