### PR TITLE
MFW-2629: MFW EOS interface configs are not loaded to sysdb on MFW BS…

### DIFF
--- a/sync-settings/Makefile
+++ b/sync-settings/Makefile
@@ -48,6 +48,7 @@ define Py3Package/sync-settings/install
 	$(INSTALL_BIN) files/startup.init $(1)/etc/init.d/startup
 	$(INSTALL_BIN) files/uid.init $(1)/etc/init.d/uid
 	$(INSTALL_BIN) files/product-board-name.init $(1)/etc/init.d/product-board-name
+	$(INSTALL_BIN) files/load-eos-config.init $(1)/etc/init.d/load-eos-config
 
 	# config/startup.d
 	$(INSTALL_DIR) $(1)/etc/config/startup.d

--- a/sync-settings/files/load-eos-config.init
+++ b/sync-settings/files/load-eos-config.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+# 17 is right after setup (16)
+#Load MFW EOS config to sysdb only if MFW runs on EOS
+START=17
+STOP=17
+
+start() {
+    if [ -f /etc/Eos-release ] ; then
+        load-eos-config
+    fi
+}
+
+stop() {
+    # Not implemented
+    true
+}


### PR DESCRIPTION
Add load-eos-config init script to load mfw eos config to sysdb