### PR TITLE
MFW-2556: send version during backup upload

### DIFF
--- a/backup-scripts/files/upload-backup.sh
+++ b/backup-scripts/files/upload-backup.sh
@@ -60,8 +60,8 @@ function callCurl() {
   debug "Calling CURL.  Dumping headers to $2"
   md5=`md5sum $1 | awk '{ print $1 }'`
   debug "Backup file MD5: $md5"
-  debug "curl $URL -k -F uid=$UID -F uploadedfile=@$1 -F md5=$md5 version=$mfw_version --dump-header $2 --max-time $TIMEOUT"
-  curl "$URL" -k -F uid="$UID" -F uploadedfile=@$1 -F md5="$md5" version="$mfw_version" --dump-header $2 --max-time $TIMEOUT > /dev/null 2>&1
+  debug "curl $URL -k -F uid=$UID -F uploadedfile=@$1 -F md5=$md5 -F version=$mfw_version --dump-header $2 --max-time $TIMEOUT"
+  curl "$URL" -k -F uid="$UID" -F uploadedfile=@$1 -F md5="$md5" -F version="$mfw_version" --dump-header $2 --max-time $TIMEOUT > /dev/null 2>&1
   return $?
 }
 

--- a/backup-scripts/files/upload-backup.sh
+++ b/backup-scripts/files/upload-backup.sh
@@ -45,6 +45,17 @@ function getHTTPStatus() {
   cat ${1} | sed -n "/HTTP\/1.1/ p" | awk '{ print $2; }' | tail -1
 }
 
+# reads the MFW version from /etc/os-release and sets it to mfw_version
+mfw_version=""
+function setMFWVersion() {
+  while IFS='=' read -r key value; do
+    if [[ $key == "VERSION" ]]; then
+      version_string="${value#*v}"            # Remove the leading 'v'
+      mfw_version="${version_string%%-*}"     # Remove everything after the first '-'
+      break
+    fi
+  done < /etc/os-release
+}
 
 # 1 = name of backup file
 # 2 = name of file to write response headers
@@ -52,7 +63,7 @@ function getHTTPStatus() {
 # returns the return of CURL
 function callCurl() {
   debug "Calling CURL.  Dumping headers to $2"
-  mfw_version=$(awk -F= '$1=="VERSION" { print $2 ;}' /etc/os-release)
+  setMFWVersion
   debug "MFW version detected: $mfw_version"
   md5=`md5sum $1 | awk '{ print $1 }'`
   debug "Backup file MD5: $md5"

--- a/backup-scripts/files/upload-backup.sh
+++ b/backup-scripts/files/upload-backup.sh
@@ -52,10 +52,12 @@ function getHTTPStatus() {
 # returns the return of CURL
 function callCurl() {
   debug "Calling CURL.  Dumping headers to $2"
+  mfw_version=$(awk -F= '$1=="VERSION" { print $2 ;}' /etc/os-release)
+  debug "MFW version detected: $mfw_version"
   md5=`md5sum $1 | awk '{ print $1 }'`
   debug "Backup file MD5: $md5"
-  debug "curl $URL -k -F uid=$UID -F uploadedfile=@$1 -F md5=$md5 --dump-header $2 --max-time $TIMEOUT"
-  curl "$URL" -k -F uid="$UID" -F uploadedfile=@$1 -F md5="$md5" --dump-header $2 --max-time $TIMEOUT > /dev/null 2>&1
+  debug "curl $URL -k -F uid=$UID -F uploadedfile=@$1 -F md5=$md5 version=$mfw_version --dump-header $2 --max-time $TIMEOUT"
+  curl "$URL" -k -F uid="$UID" -F uploadedfile=@$1 -F md5="$md5" version="$mfw_version" --dump-header $2 --max-time $TIMEOUT > /dev/null 2>&1
   return $?
 }
 


### PR DESCRIPTION
[MFW-2556](https://jira.untangle.com/browse/MFW-2556)
read MFW version from `/etc/os-release` (as restd reads the version info from here, refer: https://github.com/untangle/restd/blob/6aec907fba182fea9a56bd9bdffb9bd906deb9ba/services/gind/status.go#L428) and send it as a header while uploading the cloud backup.

**from the MFW logs**
```log
License found for: untangle-node-throughput
License found for: untangle-node-threat-prevention
License found for: untangle-node-sitefilter
License found for: untangle-node-geoip
License found for: untangle-node-classd
License found for: untangle-node-dboffload
License found for: untangle-node-discovery
Total licenses: 7
Licenses found, completing backup
Backing up settings to gunzipped tar archive file
Running backup
URL: https://boxbackup.untangle.com/boxbackup/backup.php
UID: 05de42a2-9799-491a-b0cf-7ecdf9f0868f
File: mfw_2023-05-22T06:49:08+00:00.backup.tar.gz
MFW version detected: 5.1
Calling CURL. Dumping headers to /tmp/ut-remotebackup.XXXXri2MYt
Backup file MD5: 6be1734043c5b8e2079e7b09eeaa36b4
curl https://boxbackup.untangle.com/boxbackup/backup.php -k -F uid=05de42a2-9799-491a-b0cf-7ecdf9f0868f -F uploadedfile=@mfw_2023-05-22T06:49:08+00:00.backup.tar.gz -F md5=6be1734043c5b8e2079e7b09eeaa36b4 -F version=5.1 --dump-header /tmp/ut-remotebackup.XXXXri2MYt --max-time 1200
CURL returned 0
HTTP status code
Remove header file /tmp/ut-remotebackup.XXXXri2MYt
Backup to remote URL complete
Remove backup file mfw_2023-05-22T06:49:08+00:00.backup.tar.gz
```

