### PR TITLE
MFW 3086 : On EOS VM BCTID daemon not returning correct result for threat prevention lookup

### DIFF
--- a/sync-settings/Makefile
+++ b/sync-settings/Makefile
@@ -33,7 +33,7 @@ define Py3Package/sync-settings/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sync-settings $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/load-eos-config $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bctid-provision $(1)/usr/bin
+	$(INSTALL_BIN) files/bctid-provision $(1)/usr/bin
 	$(INSTALL_BIN) files/speedtest.sh $(1)/usr/bin
 	$(INSTALL_BIN) files/wwan_status.sh $(1)/usr/bin
 	$(INSTALL_BIN) files/nft_debug $(1)/usr/bin

--- a/sync-settings/Makefile
+++ b/sync-settings/Makefile
@@ -33,6 +33,7 @@ define Py3Package/sync-settings/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sync-settings $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/load-eos-config $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bctid-provision $(1)/usr/bin
 	$(INSTALL_BIN) files/speedtest.sh $(1)/usr/bin
 	$(INSTALL_BIN) files/wwan_status.sh $(1)/usr/bin
 	$(INSTALL_BIN) files/nft_debug $(1)/usr/bin

--- a/sync-settings/files/bctid-provision
+++ b/sync-settings/files/bctid-provision
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+import subprocess
+
+class BctidProvision:
+	def __init__(self):
+		self.settings_file_path = '/etc/config/settings.json'
+		self.dns_static_entries = {'r_untangle.com'             : '34.198.106.160',
+					   'r_queue.untangle.com'       : '54.196.207.161',
+					   'r_license.untangle.com'     : '23.20.79.130',
+					   'r_cmd.untangle.com'         : '3.228.213.118',
+					   'r_boxbackup.untangle.com'   : '3.15.109.142',
+					   'r_database.untangle.com'    : '54.196.207.161',
+					   'r_api.bcti.brightcloud.com' : '35.83.77.30'}
+		self.settings_data = {}
+		self.mgmt_gateway = ""
+		self.mgmt_intf_id = 0
+		return
+
+	def get_settings_data(self):
+		with open(self.settings_file_path, "r") as settings_file:
+			self.settings_data = json.load(settings_file)
+		return
+
+	def get_mgmt_info(self):
+		self.mgmt_gateway = ""
+		for intf in self.settings_data['network']['interfaces']:
+			if(intf['name'] == 'MGMT1'):
+				self.mgmt_intf_id = intf['interfaceId']
+		return
+
+	def add_static_routes(self):
+		for name,addr in self.dns_static_entries.items():
+			route_setting = {}
+			route_setting['network'] = addr + '/32'
+			route_setting['nextHop'] = self.mgmt_gateway
+			route_setting['description'] = name
+			route_setting['interfaceId'] = self.mgmt_intf_id
+			self.settings_data['routes'].append(route_setting)
+		return
+
+	def add_dns_entries(self):
+		for name,addr in self.dns_static_entries.items():
+			dns_setting = {}
+			dns_setting['name'] = name
+			dns_setting['description'] = name
+			dns_setting['address'] = addr
+			self.settings_data['dns']['staticEntries'].append(dns_setting)
+		return
+
+	def write_settings_file(self):
+		try:
+			settings_file = open(self.settings_file_path, "w")
+			json.dump(self.settings_data, settings_file, indent=4, separators=(',', ': '))
+			settings_file.flush()
+			settings_file.close()
+		except IOError as exc:
+			print("Unable to save settings file.", exc)
+
+		return
+
+	def call_sync_settings(self):
+		try:
+			subprocess.run(['sync-settings'], capture_output=True, text=True)
+		except Exception as e:
+			print("An error occurred during sync-settings :", e)
+		return
+
+	def run(self):
+		self.get_settings_data()
+		self.get_mgmt_info()
+		self.add_static_routes()
+		self.add_dns_entries()
+		self.write_settings_file()
+		self.call_sync_settings()
+		return
+
+if __name__ == '__main__':
+
+	bctidprovision = BctidProvision()
+	bctidprovision.run()

--- a/sync-settings/files/bctid-provision
+++ b/sync-settings/files/bctid-provision
@@ -8,15 +8,16 @@ import subprocess
 class BctidProvision:
 	def __init__(self):
 		self.settings_file_path = '/etc/config/settings.json'
-		self.dns_static_entries = {'r_untangle.com'             : '34.198.106.160',
-					   'r_queue.untangle.com'       : '54.196.207.161',
-					   'r_license.untangle.com'     : '23.20.79.130',
-					   'r_cmd.untangle.com'         : '3.228.213.118',
-					   'r_boxbackup.untangle.com'   : '3.15.109.142',
-					   'r_database.untangle.com'    : '54.196.207.161',
-					   'r_api.bcti.brightcloud.com' : '35.83.77.30'}
+		self.dns_static_entries = {'untangle.com'             : '34.198.106.160',
+					   'queue.untangle.com'       : '54.196.207.161',
+					   'license.untangle.com'     : '23.20.79.130',
+					   'cmd.untangle.com'         : '3.228.213.118',
+					   'boxbackup.untangle.com'   : '3.15.109.142',
+				           'database.untangle.com'    : '54.196.207.161',
+					   'api.bcti.brightcloud.com' : '35.83.77.30'}
 		self.settings_data = {}
-		self.mgmt_gateway = ""
+		self.mgmt_name = ''
+		self.mgmt_gateway = ''
 		self.mgmt_intf_id = 0
 		return
 
@@ -26,10 +27,11 @@ class BctidProvision:
 		return
 
 	def get_mgmt_info(self):
-		self.mgmt_gateway = ""
 		for intf in self.settings_data['network']['interfaces']:
 			if(intf['name'] == 'MGMT1'):
 				self.mgmt_intf_id = intf['interfaceId']
+				self.mgmt_name = intf['device']
+		self.mgmt_gateway = subprocess.getoutput(f"ip route show dev {self.mgmt_name} | grep via | awk '{{print $3}}' | head -n 1")
 		return
 
 	def add_static_routes(self):
@@ -39,6 +41,7 @@ class BctidProvision:
 			route_setting['nextHop'] = self.mgmt_gateway
 			route_setting['description'] = name
 			route_setting['interfaceId'] = self.mgmt_intf_id
+			route_setting["enabled"] = "true"
 			self.settings_data['routes'].append(route_setting)
 		return
 
@@ -64,7 +67,7 @@ class BctidProvision:
 
 	def call_sync_settings(self):
 		try:
-			subprocess.run(['sync-settings'], capture_output=True, text=True)
+			subprocess.getoutput("sync-settings")
 		except Exception as e:
 			print("An error occurred during sync-settings :", e)
 		return


### PR DESCRIPTION
**Problem Statement**
EOS Duts running MFW doesn’t have default routes to access the internet. Due to this all the query to api.bcti.brightcloud.com servers fails and the threat lookup value doesn’t match with the actual threat value of the URL / IP as per BrightCloud.

**Proposed Solution**
As per internal discussions the solution is to bring up a configuration script that will allow current MFW to reach the BrightCloud servers. This script should be run once prior to carrying out any BCTID related testing. The final goal is to add this script as a part of provisioning stage of EOS-mfw planned in future

**Script name**
bctid-provision

**Functionality** 
Add DNS static entries and Static routes using it’s management gateway as next hop ip for the following servers

- untangle.com          
- queue.untangle.com    
- license.untangle.com   
- cmd.untangle.com       
- boxbackup.untangle.com
- database.untangle.com 
- api.bcti.brightcloud.com

This configuration will help for both license provisioning and reaching BrightCloud servers as well

Documentation of OnePager, Test validation and License provisioning attached
[Adding License to CBL Duts.pdf](https://github.com/untangle/mfw_feeds/files/12043001/Adding.License.to.CBL.Duts.pdf)
[MFW-3086 BCTID.pdf](https://github.com/untangle/mfw_feeds/files/12043003/MFW-3086.BCTID.pdf)

