### PR TITLE
MFW-3190: Added uriTranslation host for eu-launchpad

### DIFF
--- a/mfw-eu/files/settings_uri.js
+++ b/mfw-eu/files/settings_uri.js
@@ -18,6 +18,9 @@
         },{
             "uri": "https://cmd.untangle.com/",
             "host": "cmd-eu.untangle.com"
+        },{
+            "uri": "https://launchpad.edge.arista.com",
+            "host": "eu.edge.arista.com"
         }]
     }
 }


### PR DESCRIPTION
**Jira**: https://awakesecurity.atlassian.net/browse/MFW-3190

Added uriTranslation **host: https://eu.edge.arista.com** for **uri: https://launchpad.edge.arista.com**