### PR TITLE
MFW-3363 : Disabling VPN (ipsec) for MFW in EOS

### DIFF
--- a/strongswan-full/files/ipsec.init
+++ b/strongswan-full/files/ipsec.init
@@ -16,6 +16,7 @@ STRONGSWAN_CONF_FILE=/etc/strongswan.conf
 IPSEC_VAR_SECRETS_FILE=/var/ipsec/ipsec.secrets
 IPSEC_VAR_CONN_FILE=/var/ipsec/ipsec.conf
 STRONGSWAN_VAR_CONF_FILE=/var/ipsec/strongswan.conf
+platform=`cat /proc/cmdline  | xargs -n1 |grep platform |cut -d '=' -f2`
 
 WAIT_FOR_INTF=0
 
@@ -369,6 +370,9 @@ service_triggers() {
 
 start_service() {
 	prepare_env
+	if [ $platform = "councilbluffs" ] || [ $platform = "independence" ] || [ $platform = "veos" ]; then
+		return
+	fi
 
 	[ $WAIT_FOR_INTF -eq 1 ] && return
 

--- a/strongswan-full/files/ipsec.init
+++ b/strongswan-full/files/ipsec.init
@@ -16,7 +16,6 @@ STRONGSWAN_CONF_FILE=/etc/strongswan.conf
 IPSEC_VAR_SECRETS_FILE=/var/ipsec/ipsec.secrets
 IPSEC_VAR_CONN_FILE=/var/ipsec/ipsec.conf
 STRONGSWAN_VAR_CONF_FILE=/var/ipsec/strongswan.conf
-platform=`cat /proc/cmdline  | xargs -n1 |grep platform |cut -d '=' -f2`
 
 WAIT_FOR_INTF=0
 
@@ -370,9 +369,6 @@ service_triggers() {
 
 start_service() {
 	prepare_env
-	if [ $platform = "councilbluffs" ] || [ $platform = "independence" ] || [ $platform = "veos" ]; then
-		return
-	fi
 
 	[ $WAIT_FOR_INTF -eq 1 ] && return
 

--- a/strongswan-full/files/override.ipsec.init
+++ b/strongswan-full/files/override.ipsec.init
@@ -16,7 +16,7 @@ STRONGSWAN_CONF_FILE=/etc/strongswan.conf
 IPSEC_VAR_SECRETS_FILE=/var/ipsec/ipsec.secrets
 IPSEC_VAR_CONN_FILE=/var/ipsec/ipsec.conf
 STRONGSWAN_VAR_CONF_FILE=/var/ipsec/strongswan.conf
-platform=`cat /proc/cmdline  | xargs -n1 |grep platform |cut -d '=' -f2`
+platform=`awk '{for(i=1;i<=NF;i++) if($i ~ /platform/) print $i}' /proc/cmdline | cut -d '=' -f2`
 
 WAIT_FOR_INTF=0
 

--- a/strongswan-full/files/override.ipsec.init
+++ b/strongswan-full/files/override.ipsec.init
@@ -16,6 +16,7 @@ STRONGSWAN_CONF_FILE=/etc/strongswan.conf
 IPSEC_VAR_SECRETS_FILE=/var/ipsec/ipsec.secrets
 IPSEC_VAR_CONN_FILE=/var/ipsec/ipsec.conf
 STRONGSWAN_VAR_CONF_FILE=/var/ipsec/strongswan.conf
+platform=`cat /proc/cmdline  | xargs -n1 |grep platform |cut -d '=' -f2`
 
 WAIT_FOR_INTF=0
 
@@ -393,6 +394,9 @@ service_triggers() {
 
 start_service() {
 	prepare_env
+	if [ $platform = "councilbluffs" ] || [ $platform = "independence" ] || [ $platform = "veos" ]; then
+		return
+	fi
 
 	[ $WAIT_FOR_INTF -eq 1 ] && return
 


### PR DESCRIPTION
This is a part of
MFW-3363: Disabling VPN's for MFW-in-EOS
Pls find the link to the PR in other repos for the same ticket below:
https://github.com/untangle/restd/pull/167

ipsec process would start automatically when the BST container comes up 

-bash-4.2# ps -ef | grep ipsec
3072 root      1792 S    /usr/lib/ipsec/starter --daemon charon --nofork
3128 root      5492 S    /usr/lib/ipsec/charon
-bash-4.2#

Disabling Ipsec process for ipsec.init for EOS-MFW platform 

AFTER change:

-bash-4.2# ps -ef | grep ipsec
root      3575     2  0 10:36 ?        00:00:00 [ipsec_inline_in]
root      3576     2  0 10:36 ?        00:00:00 [ipsec_inline_mb]
root      3577     2  0 10:36 ?        00:00:00 [ipsec_inline_sb]
root      3578     2  0 10:36 ?        00:00:00 [ipsec_inline_vf]
root     13856 13644  0 10:38 pts/3    00:00:00 grep --color=auto ipsec
-bash-4.2#

