### PR TITLE
MFW-3790 Modify Interrupt distribution and enable RPS/XPS/HT to impro…

### DIFF
--- a/sync-settings/Makefile
+++ b/sync-settings/Makefile
@@ -38,6 +38,8 @@ define Py3Package/sync-settings/install
 	$(INSTALL_BIN) files/wwan_status.sh $(1)/usr/bin
 	$(INSTALL_BIN) files/nft_debug $(1)/usr/bin
 	$(INSTALL_BIN) files/check-for-usb-reset.sh $(1)/usr/bin
+	$(INSTALL_BIN) files/set_affinity.sh $(1)/usr/bin
+	$(INSTALL_BIN) files/set_rpsxps.sh $(1)/usr/bin
 
 	# init.d
 	$(INSTALL_DIR) $(1)/etc/init.d

--- a/sync-settings/files/set_affinity.sh
+++ b/sync-settings/files/set_affinity.sh
@@ -47,7 +47,7 @@ set)
 	;;
 
 *)
-	echo "Usage: set_affinity show|configure"
+	echo "Usage: set_affinity show|set"
 	exit 1
 esac
 

--- a/sync-settings/files/set_affinity.sh
+++ b/sync-settings/files/set_affinity.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+if [ -z "$NCPUS" ]; then
+	NCPUS=$(grep processor /proc/cpuinfo | wc -l)
+fi
+
+if [ -z "$DEVLIST" ]; then
+	DEVLIST=$(cd /sys/class/net; ls -1d et1_* | sort -t_ -k2n)
+fi
+
+case $1 in
+show)
+	for d in $DEVLIST
+	do
+		irqs=$(grep "iavf-$d-" /proc/interrupts | awk -F: '{print $1}')
+		printf "%s	irqs: " $d
+		aflist=
+		for irq in $irqs
+		do
+			al=$(cat /proc/irq/$irq/smp_affinity_list)
+			aflist="$aflist $al"
+			printf "%5d" $irq
+		done
+		printf "\n\tcore: "
+		for al in $aflist
+		do
+			printf "%5d" $al
+		done
+		printf "\n"
+	done
+	;;
+
+set)
+	af=0
+	for d in $DEVLIST
+	do
+		# Setup CPU affinity
+		irqs=$(grep "iavf-$d-" /proc/interrupts | awk -F: '{print $1}')
+		for irq in $irqs
+		do
+			# echo "Set smp_affinity: $d irq=$irq $af"
+			echo $af > /proc/irq/$irq/smp_affinity_list
+			af=$((af+1))
+			[ $af -eq $NCPUS ] && af=0
+		done
+	done
+	;;
+
+*)
+	echo "Usage: set_affinity show|configure"
+	exit 1
+esac
+
+exit 0

--- a/sync-settings/files/set_rpsxps.sh
+++ b/sync-settings/files/set_rpsxps.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+if [ -z "$DEVLIST" ]; then
+	DEVLIST=$(cd /sys/class/net; ls -1d et1_* | sort -t_ -k2n)
+fi
+
+# 40 CPUs
+CPUMASK_ALL="ff,ffffffff"
+
+case $1 in
+show)
+	for d in $DEVLIST
+	do
+		for rx in $(cd /sys/class/net/$d/queues; ls -1d rx-*)
+		do
+			mask=$(cat /sys/class/net/$d/queues/$rx/rps_cpus)
+			echo $d $rx  $mask
+		done
+		for tx in $(cd /sys/class/net/$d/queues; ls -1d tx-*)
+		do
+			mask=$(cat /sys/class/net/$d/queues/$tx/xps_cpus)
+			echo $d $tx  $mask
+		done
+	done
+	;;
+set|revert)
+	[ $1 = revert ] && CPUMASK_ALL=0
+
+	for d in $DEVLIST
+	do
+		for rx in $(cd /sys/class/net/$d/queues; ls -1d rx-*)
+		do
+			echo $CPUMASK_ALL > /sys/class/net/$d/queues/$rx/rps_cpus
+		done
+		for tx in $(cd /sys/class/net/$d/queues; ls -1d tx-*)
+		do
+			echo $CPUMASK_ALL > /sys/class/net/$d/queues/$tx/xps_cpus
+		done
+	done
+	;;
+*)
+	echo "Usage: set_rpsxps show|set|revert"
+	exit 1
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
…ve network throughput

Please see [MFW-3790](https://awakesecurity.atlassian.net/browse/MFW-3790) for the detail.
Adding 2 shell scripts set_affinity.sh and set_rpsxps.sh.
The set_affinity.sh script is run by a ifup script generated by sync-settings and modify interrupt distribution.
The set_rpsxps.sh is run in the same way, and set RPS/XPS settings for all TxRx queues.


[MFW-3790]: https://awakesecurity.atlassian.net/browse/MFW-3790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ