### PR TITLE
Quota changes

### DIFF
--- a/sync-settings/Makefile
+++ b/sync-settings/Makefile
@@ -38,6 +38,7 @@ define Py3Package/sync-settings/install
 	$(INSTALL_BIN) files/wwan_status.sh $(1)/usr/bin
 	$(INSTALL_BIN) files/nft_debug $(1)/usr/bin
 	$(INSTALL_BIN) files/check-for-usb-reset.sh $(1)/usr/bin
+	$(INSTALL_BIN) files/quota_cron.sh $(1)/usr/bin
 
 	# init.d
 	$(INSTALL_DIR) $(1)/etc/init.d

--- a/sync-settings/files/quota_cron.sh
+++ b/sync-settings/files/quota_cron.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+export CMD_MATCH=$1
+export FULL_CMD=$2
+c_temp=$(nft list chain inet shaping quota-rules -a | grep "$CMD_MATCH")
+c_tmp=${c_temp#*handle}
+nft delete rule inet shaping quota-rules handle $c_tmp
+$FULL_CMD


### PR DESCRIPTION
New shell script which runs as part of cronjob. This script is currently used by Quota Manager to schedule NFT rule delete/readd after the time expires.