### PR TITLE
MFW-3719: Adding a boot config checkout flag for load-eos-config

### DIFF
--- a/sync-settings/files/load-eos-config.init
+++ b/sync-settings/files/load-eos-config.init
@@ -7,7 +7,7 @@ STOP=17
 
 start() {
     if [ -f /etc/Eos-release ] ; then
-        load-eos-config
+        load-eos-config -b
     fi
 }
 

--- a/sync-settings/files/load-eos-config.init
+++ b/sync-settings/files/load-eos-config.init
@@ -7,7 +7,7 @@ STOP=17
 
 start() {
     if [ -f /etc/Eos-release ] ; then
-        load-eos-config -b
+        load-eos-config --save-boot-config
     fi
 }
 


### PR DESCRIPTION
Calling the load-eos-config with "-b" flag to copy the running-config to startup-config during boot up.
PR for introducing the -b flag : https://github.com/untangle/sync-settings/pull/587