### PR TITLE
MFW-4475: For latency, ceil the values instead of flooring

### DIFF
--- a/wan-manager/files/wan-manager
+++ b/wan-manager/files/wan-manager
@@ -385,6 +385,10 @@ get_static_weight()
 	eval "$__return_weight=$__weight"
 }
 
+# ceil
+# It ceils or it rounds up the input number to the next nearest integer.
+#
+# @param $1	   The number that is to be ceiled.
 ceil()
 {
 	  echo "$1" | awk '{printf "%d\n", ($1 == int($1)) ? $1 : int($1) + 1}'

--- a/wan-manager/files/wan-manager
+++ b/wan-manager/files/wan-manager
@@ -385,6 +385,11 @@ get_static_weight()
 	eval "$__return_weight=$__weight"
 }
 
+ceil()
+{
+	  echo "$1" | awk '{printf "%d\n", ($1 == int($1)) ? $1 : int($1) + 1}'
+}
+
 # get_stat
 # Retrieve specific stats from the /tmp/stats.json file, per interface id
 #
@@ -434,7 +439,13 @@ get_stat()
 							json_select $metric
 							json_get_vars name value
 							if [ $metric_name = $name ] ; then
-								stat_value=$(echo ${value%%.*})
+								if [ $stat_name = "latency" ] ; then
+									# During policy_best_of calculations, a latency of 0 gets ignored (this is only for latency),
+									# so instead of flooring, ceil the latency value because 0.45 latency is also valid, ceil it to 1.
+									stat_value=$(ceil $value)
+								else
+									stat_value=$(echo ${value%%.*})
+								fi
 							fi
 							json_select ..
 						done


### PR DESCRIPTION
**Jira:** https://awakesecurity.atlassian.net/browse/MFW-4475
**Root-cause:** We were flooring the statistics when getting them from stats.json & values lower than 1 (like 0.45) were getting floored to 0. For latency, there's a check that skips any WANs that have 0 latency, considering them as 100% packet loss WAN (offline). 
**Changes:** Even a latency of 0.45 is a valid latency & should not be skipped. So for latency, ceil the values. So 0.45 gets ceiled to 1 & does not get skipped. Only WANs with exactly 0 latency would get skipped.