### PR TITLE
MFW-5697: Added support for q4, q8, e4 and e8 product_board_names

### DIFF
--- a/sync-settings/files/product-board-name.init
+++ b/sync-settings/files/product-board-name.init
@@ -48,7 +48,7 @@ boot() {
 	# Q series serial pattern CTWYYWWSSSS
 	# YYWWSSSS is a series of digits representing the year, number of weeks, and a sequence number
 	qSerialPattern="^CTW([1-9][0-9])(0[1-9]|[1-4][0-9]|5[0-3])([0-9]{4})$"
-	eth_intf_count=$(ls /proc/sys/net/ipv4/conf/ | grep eth*  | wc -l)
+	eth_intf_count=$(find /proc/sys/net/ipv4/conf/ -name 'eth*' | wc -l)
 	case $(board_name) in
 	globalscale,espressobin-v7-emmc)
 		product_board_name="e3"

--- a/sync-settings/files/product-board-name.init
+++ b/sync-settings/files/product-board-name.init
@@ -48,7 +48,7 @@ boot() {
 	# Q series serial pattern CTWYYWWSSSS
 	# YYWWSSSS is a series of digits representing the year, number of weeks, and a sequence number
 	qSerialPattern="^CTW([1-9][0-9])(0[1-9]|[1-4][0-9]|5[0-3])([0-9]{4})$"
-	eth_intf_count=$(find /proc/sys/net/ipv4/conf/ -name 'eth*' | sed -e 's|/proc/sys/net/ipv4/conf/||' | wc -l)
+	eth_intf_count=$(ls /proc/sys/net/ipv4/conf/ | grep eth*  | wc -l)
 	case $(board_name) in
 	globalscale,espressobin-v7-emmc)
 		product_board_name="e3"
@@ -66,7 +66,7 @@ boot() {
 			fi
 		else
 			# Handle NON Q series board name.
-			product_board_name="e${eth_intf_count}6"
+			product_board_name="e${eth_intf_count}"
 		fi
 
 		if [ -L /sys/class/ieee80211/phy0 ]; then

--- a/sync-settings/files/product-board-name.init
+++ b/sync-settings/files/product-board-name.init
@@ -48,7 +48,7 @@ boot() {
 	# Q series serial pattern CTWYYWWSSSS
 	# YYWWSSSS is a series of digits representing the year, number of weeks, and a sequence number
 	qSerialPattern="^CTW([1-9][0-9])(0[1-9]|[1-4][0-9]|5[0-3])([0-9]{4})$"
-
+	eth_intf_count=$(find /proc/sys/net/ipv4/conf/ -name 'eth*' | sed -e 's|/proc/sys/net/ipv4/conf/||' | wc -l)
 	case $(board_name) in
 	globalscale,espressobin-v7-emmc)
 		product_board_name="e3"
@@ -60,10 +60,13 @@ boot() {
 	caswell-caf-0262 | untangle-inc-default-string | arista-networks-inc-default-string)
 		if [[ $SERIAL =~ $qSerialPattern ]]; then
 			# Handle Q series board name.
-			product_board_name="Q6E"
+			product_board_name="Q${eth_intf_count}"
+			if [ eth_intf_count==6 ]; then
+				product_board_name=$product_board_name"E"
+			fi
 		else
 			# Handle NON Q series board name.
-			product_board_name="e6"
+			product_board_name="e${eth_intf_count}6"
 		fi
 
 		if [ -L /sys/class/ieee80211/phy0 ]; then


### PR DESCRIPTION
It checks number of eth* devices on the board and usees it to populate the product_board name for e and q series devices.
For Q series writes Q6 as Q6e
- [x] Did you name your branch and commit in the right format?
- [x] Did you raise the PR on the correct branch?
- [x] Did you merge the target branch before creating this PR?
- [ ] Did you add unit tests for your changes
- [ ] Did you create structs instead of using interfaces
- [x] Did you test your work
- [x] Did you make sure to DRY your code?  Were you able to refactor existing code for reuse instead of making similar code?
- [ ] Did you break your code into smaller methods or components that each have a clear, singular responsibility, and could possibly be reused?
- [ ] Did you reduce the nesting level in your code, so it is not more than three levels nested in a method?  Did you return early to reduce nesting?
- [ ] Did you add comments so for instance a new developer would understand this code, and understand any business logic?
- [ ] Did you add an intranet note/page if this is new behavior/feature 
- [x] Did you resolve all conversations on the PR?