### PR TITLE
overwrite automerge schedule for barnzilla-repos

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,11 @@
+{
+    "automergeSchedule": ["at any time"],
+
+    packageRules: [
+        {
+            "matchDatasources": ["custom.bar"],
+            "matchPackageNames": ["code.arista.io/infra/barney/barnzilla-repos"],
+            "automergeSchedule": ["at any time"]
+        }
+    ]
+}


### PR DESCRIPTION
As recommended by Braney-ci/Renovate maintainers we need to overwrite rule for code.arista.io/infra/barney/barnzilla-repos if we want it to automerge.

The example from the team

packageRules: [
{
"matchDatasources": ["custom.bar"],
"matchPackageNames": ["code.arista.io/infra/barney/barnzilla-repos"], "automergeSchedule": ["at any time"]
}
]
```