### PR TITLE
MFW-5803: Updated cJSON dependency for bctid

### DIFF
--- a/bctid/Makefile
+++ b/bctid/Makefile
@@ -19,7 +19,7 @@ define Package/bctid
   SUBMENU:=Firewall
   TITLE:=Brightcloud classification daemon
   URL:=https://github.com/untangle/bctid
-  DEPENDS:=+libidn2 +libstdcpp +libopenssl +zlib
+  DEPENDS:=+libidn2 +libstdcpp +libopenssl +zlib +cJSON
 endef
 
 define Package/bctid/description

--- a/configs/common/openwrt_packages
+++ b/configs/common/openwrt_packages
@@ -2,6 +2,7 @@ CONFIG_PACKAGE_at=y
 CONFIG_PACKAGE_ath10k-firmware-qca988x=y
 CONFIG_PACKAGE_bind-dig=y
 CONFIG_PACKAGE_ca-certificates=y
+CONFIG_PACKAGE_cJSON=y
 CONFIG_PACKAGE_conntrack=y
 CONFIG_PACKAGE_diffutils=y
 CONFIG_PACKAGE_ethtool=y


### PR DESCRIPTION
**Jira**: https://awakesecurity.atlassian.net/browse/MFW-5803

1. This PR: In mfw_feeds, added cJSON dependency and enabled cJSON in openwrt_packages.
2. Related [packetd PR](https://github.com/untangle/packetd/pull/1146): In packetd, changed “catid” to “cat”, because the new bctid version requires it to be done: https://github.com/untangle/bctid/pull/157/files#diff-c71253f491e018b400f1ee33c8b044aac89feb85ebdbf8550275a56ddb14e845R24  