### PR TITLE
add patch that does nothing so we override inappriate patch from open…

### DIFF
--- a/configs/overrides/packages/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
+++ b/configs/overrides/packages/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
@@ -1,0 +1,11 @@
+--- src/cmd/link/internal/ld/lib.go	2024-08-29 14:56:24.000000000 -0600
++++ src/cmd/link/internal/ld/lib1.go	2024-11-27 14:27:47.064944364 -0700
+@@ -28,7 +28,7 @@
+ // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ // THE SOFTWARE.
+ 
+-package ld
++package ld
+ 
+ import (
+ 	"bytes"

--- a/configs/overrides/packages/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
+++ b/configs/overrides/packages/lang/golang/golang/patches/001-cmd-link-use-gold-on-ARM-ARM64-only-if-gold-is-available.patch
@@ -1,5 +1,5 @@
---- src/cmd/link/internal/ld/lib.go	2024-08-29 14:56:24.000000000 -0600
-+++ src/cmd/link/internal/ld/lib1.go	2024-11-27 14:27:47.064944364 -0700
+--- a/src/cmd/link/internal/ld/lib.go	2024-08-29 14:56:24.000000000 -0600
++++ b/src/cmd/link/internal/ld/lib.go	2024-11-27 14:27:47.064944364 -0700
 @@ -28,7 +28,7 @@
  // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  // THE SOFTWARE.


### PR DESCRIPTION
The issue is that in the 21.02 packages version for golang we have directory with patches which our override do not remove before replacing it with the newer golang. Since our override is based on ‘rsync’ and we do not use the --delete option, we leave in place stuff existing files. The openwrt build system automatically looks for folders named ‘patches’ and applies the patch. So to remedy this I’ve created an empty patch that will override the one from 21.02 packages.
