### PR TITLE
Added secret-manager dependency to sync-settings

### DIFF
--- a/sync-settings/Makefile
+++ b/sync-settings/Makefile
@@ -21,7 +21,7 @@ define Package/sync-settings
   DEPENDS:= +diffutils +tc +kmod-sched +kmod-sched-cake +kmod-ifb +kmod-sched-connmark +kmod-nf-conncount +kmod-nft-connlimit \
 	  +uuidgen +kmod-nft-fib +openvpn-proto +wan-manager +speedtest-cli \
 	  +python3 +python3-urllib3 +python3-pyroute2 +python3-requests +strongswan-default +strongswan-mod-gcm \
-	  +jq +nmap-ssl +lldpd +kmod-wireguard +wireguard-tools +python3-cryptography
+	  +jq +nmap-ssl +lldpd +kmod-wireguard +wireguard-tools +python3-cryptography +secret-manager
 endef
 
 define Package/sync-settings/description


### PR DESCRIPTION
[Build #15 for mfw-release-6.1](http://jenkins.untangle.int/job/MFW%20pipeline/job/mfw-release-6.1/15/consoleFull) did not have password-manager binary. So we have added secret-manager as a dependency to sync-settings hoping that it would trigger secret-manager installation and eventually copy the password-manager binary.