### PR TITLE
Sync-settings freezes on E6 on reboot after ipsec interface creation

### DIFF
--- a/barney.context
+++ b/barney.context
@@ -26,7 +26,7 @@
 			"commit": "d909fa71e4fe270577d2419e0250302d20b4b07a"
 		},
 		"code.arista.io/infra/barney/barnzilla-repos": {
-			"commit": "827df5bbc9b0e16efd6a61243ab4a1a4dd42655c"
+			"commit": "5d915dad06a41f628f6238521288ccc1e042dabd"
 		},
 		"code.arista.io/infra/barney/tools/qube": {
 			"commit": "7ea12f3a4f3683689fd7670b26015bf374216d10"

--- a/pyconnector/files/pyconnector.init
+++ b/pyconnector/files/pyconnector.init
@@ -16,7 +16,7 @@ get_translated_host()
         # Only host - add https:// for lookup
         uri="https://"$uri"/"
     fi
-    translated_url=$(wget -qO- "http://127.0.0.1/api/uri/geturiwithpath/uri=$uri")
+    translated_url=$(wget --timeout=30 --tries=1 -qO- "http://127.0.0.1/api/uri/geturiwithpath/uri=$uri")
     if [ "translated_url" != "" ] ; then
         host=$translated_url
     fi


### PR DESCRIPTION
From the investigation [MFW-6296](https://awakesecurity.atlassian.net/browse/MFW-6296): pyconnector was failing for E6 device on reboot.

Root Cause: In the URI translation process, wget is used to make a call to `http://127.0.0.1/api/uri/geturiwithpath/uri=$uri` without a timeout.

now for `wget` added timeout=30 with tries=1, 

 tries=1 is required. Since the default is 20 retries, if the server is unreachable or the address is invalid, wget will make up to 20 attempts to reach the server.

If URI translation process fails, then fallback is added at https://github.com/untangle/mfw_feeds/blob/mfw-release-6.1/pyconnector/files/pyconnector.init#L73


[MFW-6296]: https://awakesecurity.atlassian.net/browse/MFW-6296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ