### PR TITLE
MFW-803 Trying to add open-vm-tools

### DIFF
--- a/configs/common/openwrt_packages
+++ b/configs/common/openwrt_packages
@@ -42,6 +42,7 @@ CONFIG_PACKAGE_libzmq-curve=y
 CONFIG_PACKAGE_lldpd=y
 CONFIG_PACKAGE_nano=y
 CONFIG_PACKAGE_nmap-ssl=y
+CONFIG_PACKAGE_open-vm-tools=y
 CONFIG_PACKAGE_python3-pyroute2=y
 CONFIG_PACKAGE_python3-urllib3=y
 CONFIG_PACKAGE_python3=y


### PR DESCRIPTION
Added CONFIG_PACKAGE_open-vm-tools=y to mfw_feeds/configs/common/openwrt_packages
Also have to add a dependency on the package so that it is included in the build.