### PR TITLE
[EFW-874] Clean up dependencies

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -6,13 +6,11 @@ images:
     units:
     - image: code.arista.io/infra/barney/barnzilla%base
     - image: code.arista.io/infra/barney/barnzilla%network
-    - image: code.arista.io/infra/barney/barnzilla%rpms/yum
-    - image: code.arista.io/infra/barney/barnzilla%rpms/yum-utils
-    - image: code.arista.io/infra/barney/barnzilla%rpms/wget/fakeroot/sudo/EosImage/EosImageBuildUtils/EosUtils/EosSwimUtils
-    - image: code.arista.io/infra/barney/barnzilla%rpms/rpm-build
-    - image: code.arista.io/infra/barney/barnzilla%rpmdb
-    - image: code.arista.io/infra/barney/barnzilla%rpms/jq
     - image: code.arista.io/infra/barney/barnzilla%rpms/bash
+    - image: code.arista.io/infra/barney/barnzilla%rpms/jq
+    - image: code.arista.io/infra/barney/barnzilla%rpms/rpm-build
+    - image: code.arista.io/infra/barney/barnzilla%rpms/wget
+    - image: code.arista.io/infra/barney/barnzilla%rpmdb
 
   # Create the mfw-feeds RPM consisting of some basic scripts
   mfw_pkg/mfw-feeds-rpm:


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/EFW-874

`efw_feeds` will now be included as a part of `EfwSfe`, so it cannot depend on packages that depend on `EfwSfe`